### PR TITLE
Update bond.sh

### DIFF
--- a/bond.sh
+++ b/bond.sh
@@ -10,7 +10,7 @@ PUB_KEY_HEX='PUBLIC_HEX'
 
 BID_AMOUNT="101010101"
 
-GAS="1000000000" # So far this is minimum which I be able to achive, 9 zeros
+GAS="10000000000" # So far this is minimum which I be able to achive, 10 zeros
 
 PROFIT="10"
 


### PR DESCRIPTION
GAS with 1000000000 (9 Zeroes) is giving error. 

Deploy command Reference from https://docs.casperlabs.io/en/latest/node-operator/bonding.html?highlight=add_bid.wasm#bonding: 

casper-client put-deploy --chain-name <CHAIN_NAME> --node-address http://<HOST:PORT> --secret-key /etc/casper/<VALIDATOR_SECRET_KEY>.pem --session-path  $HOME/casper-node/target/wasm32-unknown-unknown/release/add_bid.wasm  --payment-amount 10000000000  --session-arg="public_key:public_key='<VALIDATOR_PUBLIC_KEY_HEX>'" --session-arg="amount:u512='<BID-AMOUNT>'" --session-arg="delegation_rate:u64='<PERCENT_TO_KEEP_FROM_DELEGATORS>'"


Hence Updated as :
GAS="10000000000" # So far this is minimum which I be able to achive, 10 zeros