### PR TITLE
Update to new SSE endpoint (breaking change in casper-node 1.3.1)

### DIFF
--- a/status.py
+++ b/status.py
@@ -941,7 +941,7 @@ class EventTask:
         global localhost
         global round_time
         global avg_rnd_time
-        url = 'http://{}:9999/events'.format(localhost)
+        url = 'http://{}:9999/events/main'.format(localhost)
         localhost_active = False
         while not localhost_active and self._running:
             try:


### PR DESCRIPTION
Today the Casper testnet was upgraded to 1.3.1 and one major and breaking change was new SSE endpoints.

I didn't include any version check so you can add it or just wait until the mainnet will be upgraded, too which usually happens a few days later.

Full Changelog for Casper is found here:
https://github.com/casper-network/casper-node/releases/tag/v1.3.1